### PR TITLE
Fix: Adjust colour description to images

### DIFF
--- a/client/src/pages/guide/english/css/css3-gradients/index.md
+++ b/client/src/pages/guide/english/css/css3-gradients/index.md
@@ -132,4 +132,6 @@ The following example shows a linear gradient that starts at top left (and goes 
 
 #### More Information:
 <!-- Please add any articles you think might be helpful to read before writing the article -->
-[MDN Documentatiion](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient) || [w3schools](https://www.w3schools.com/css/css3_gradients.asp) || [CSS Tricks](https://css-tricks.com/snippets/css/css-linear-gradient/)
+- [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient)
+- [W3Schools](https://www.w3schools.com/css/css3_gradients.asp)
+- [CSS Tricks](https://css-tricks.com/snippets/css/css-linear-gradient/)

--- a/client/src/pages/guide/english/css/css3-gradients/index.md
+++ b/client/src/pages/guide/english/css/css3-gradients/index.md
@@ -20,7 +20,7 @@ To create a linear gradient you must define at least two color stops. Color stop
     background: linear-gradient(direction, color-stop1, color-stop2, ...);
 
 ##### Linear Gradient - Top to Bottom (this is default)
-The following example shows a linear gradient that starts at the top. It starts red, transitioning to yellow:
+The following example shows a linear gradient that starts at the top. It starts red, transitioning to green:
 ![default-linear-gradient](https://i.imgur.com/2uGfleD.jpg)
 
 #### Example
@@ -42,7 +42,7 @@ The following example shows a linear gradient that starts at the top. It starts 
 <body>
 
 <h3>Linear Gradient - Top to Bottom</h3>
-<p>This linear gradient starts at the top. It starts red, transitioning to yellow:</p>
+<p>This linear gradient starts at the top. It starts red, transitioning to green:</p>
 
 <div id="grad1"></div>
 
@@ -55,7 +55,7 @@ The following example shows a linear gradient that starts at the top. It starts 
 ![default-linear-gradient](https://i.imgur.com/CvtXCMd.jpg)
 
 ##### Linear Gradient - Left to Right
-The following example shows a linear gradient that starts from the left. It starts red, transitioning to yellow:
+The following example shows a linear gradient that starts from the left. It starts red, transitioning to green:
 ![left-to-right](https://i.imgur.com/e4dRvZR.jpg)
 
 #### Example
@@ -78,7 +78,7 @@ The following example shows a linear gradient that starts from the left. It star
 <body>
 
 <h3>Linear Gradient - Left to Right</h3>
-<p>This linear gradient starts at the left. It starts red, transitioning to yellow:</p>
+<p>This linear gradient starts at the left. It starts red, transitioning to green:</p>
 
 <div id="grad1"></div>
 
@@ -94,7 +94,7 @@ The following example shows a linear gradient that starts from the left. It star
 
 You can make a gradient diagonally by specifying both the horizontal and vertical starting positions.
 
-The following example shows a linear gradient that starts at top left (and goes to bottom right). It starts red, transitioning to yellow:
+The following example shows a linear gradient that starts at top left (and goes to bottom right). It starts red, transitioning to green:
 
 ![diagonal](https://i.imgur.com/YvtbUBH.jpg)
 
@@ -118,7 +118,7 @@ The following example shows a linear gradient that starts at top left (and goes 
 <body>
 
 <h3>Linear Gradient - Diagonal</h3>
-<p>This linear gradient starts at top left. It starts red, transitioning to yellow:</p>
+<p>This linear gradient starts at top left. It starts red, transitioning to green:</p>
 
 <div id="grad1"></div>
 
@@ -132,4 +132,4 @@ The following example shows a linear gradient that starts at top left (and goes 
 
 #### More Information:
 <!-- Please add any articles you think might be helpful to read before writing the article -->
-[MDN Documentatiion](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient) || [w3schools](https://www.w3schools.com/css/css3_gradients.asp)
+[MDN Documentatiion](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient) || [w3schools](https://www.w3schools.com/css/css3_gradients.asp) || [CSS Tricks](https://css-tricks.com/snippets/css/css-linear-gradient/)


### PR DESCRIPTION
The text says that the gradient goes from red to yellow, but in all pictures, the gradients go from red to green. I substituted "yellow" by "green" in the text.

I also added a new resource (CSS Tricks) with more examples for CSS linear gradients.

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
